### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@
 **MCP Filesystem Server** provides secure filesystem access for AI models through the Model Context Protocol. It
 enforces strict path validation and only allows access to predefined directories.
 
+<a href="https://glama.ai/mcp/servers/@A-Niranjan/mcp-filesystem">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@A-Niranjan/mcp-filesystem/badge" alt="Filesystem Server MCP server" />
+</a>
+
 <br>
 
 ## :computer: Technologies


### PR DESCRIPTION
This PR adds a badge for the [MCP Filesystem Server](https://glama.ai/mcp/servers/@A-Niranjan/mcp-filesystem) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@A-Niranjan/mcp-filesystem">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@A-Niranjan/mcp-filesystem/badge" alt="Filesystem Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.